### PR TITLE
Optionally render full image range and disable drawing of FWHM aperture

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -48,10 +48,15 @@ class FITSFileEditor {
                             // Convert the document URI to a webview URI
                             const fitsFileUri = webviewPanel.webview.asWebviewUri(document.uri);
 
+                            // Read the autoZScale setting
+                            const config = vscode.workspace.getConfiguration('simple-fits-viewer');
+                            const autoZScale = config.get('autoZScale', true);
+
                             // Send the data to the webview
                             webviewPanel.webview.postMessage({
                                 command: 'loadData',
-                                fileUri: fitsFileUri.toString()
+                                fileUri: fitsFileUri.toString(),
+                                autoZScale: autoZScale
                             });
                         }
 
@@ -76,6 +81,18 @@ class FITSFileEditor {
         // Initial update
         updateWebview();
 
+        // Listen for setting changes and notify the webview
+        const configChangeSubscription = vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration('simple-fits-viewer.autoZScale')) {
+                const config = vscode.workspace.getConfiguration('simple-fits-viewer');
+                const autoZScale = config.get('autoZScale', true);
+                webviewPanel.webview.postMessage({
+                    command: 'settingChanged',
+                    autoZScale: autoZScale
+                });
+            }
+        });
+
         // Handle document changes
         const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(event => {
             if (event.document.uri.toString() === document.uri.toString()) {
@@ -83,9 +100,10 @@ class FITSFileEditor {
             }
         });
 
-        // Clean up subscription when panel is disposed
+        // Clean up subscriptions when panel is disposed
         webviewPanel.onDidDispose(() => {
             changeDocumentSubscription.dispose();
+            configChangeSubscription.dispose();
         });
     }
 

--- a/extension.js
+++ b/extension.js
@@ -51,12 +51,14 @@ class FITSFileEditor {
                             // Read the autoZScale setting
                             const config = vscode.workspace.getConfiguration('simple-fits-viewer');
                             const autoZScale = config.get('autoZScale', true);
+                            const doDrawApertureCircles = config.get('drawApertureCircles', true);
 
                             // Send the data to the webview
                             webviewPanel.webview.postMessage({
                                 command: 'loadData',
                                 fileUri: fitsFileUri.toString(),
-                                autoZScale: autoZScale
+                                autoZScale: autoZScale,
+                                doDrawApertureCircles: doDrawApertureCircles
                             });
                         }
 
@@ -89,6 +91,14 @@ class FITSFileEditor {
                 webviewPanel.webview.postMessage({
                     command: 'settingChanged',
                     autoZScale: autoZScale
+                });
+            }
+            if (e.affectsConfiguration('simple-fits-viewer.drawApertureCircles')) {
+                const config = vscode.workspace.getConfiguration('simple-fits-viewer');
+                const doDrawApertureCircles = config.get('drawApertureCircles', true);
+                webviewPanel.webview.postMessage({
+                    command: 'settingChanged',
+                    doDrawApertureCircles: doDrawApertureCircles
                 });
             }
         });

--- a/package.json
+++ b/package.json
@@ -61,7 +61,17 @@
                     }
                 ]
             }
-        ]
+        ],
+        "configuration": {
+            "title": "Simple FITS Viewer",
+            "properties": {
+                "simple-fits-viewer.autoZScale": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Automatically apply z-scale stretch when opening FITS images. When disabled, images display with full data range."
+                }
+            }
+        }
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Automatically apply z-scale stretch when opening FITS images. When disabled, images display with full data range."
+                },
+                "simple-fits-viewer.drawApertureCircles": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Draw FWHM aperture circles"
                 }
             }
         }

--- a/utils.js
+++ b/utils.js
@@ -111,9 +111,14 @@ function parseFITSImage(arrayBuffer, dataView) {
     }
     offset += totalBytes;
     console.timeLog("parseFITSImage", "parseFITSImageData");
+    console.timeEnd("parseFITSImage", "parseFITSImage done");
 
+    // console.log(header, normalizedData);
+    return [header, width, height, data];
+}
+
+function normalizeData(data, vmin, vmax) {
     // Normalize Data for Display
-    const { vmin, vmax } = zscale(data);
     console.timeLog("parseFITSImage", "zscale");
     // const normalizedData = data.map(
     //     (value) => ((value - vmin) / (vmax - vmin)) * 255
@@ -125,17 +130,15 @@ function parseFITSImage(arrayBuffer, dataView) {
     for (let i = 0; i < data.length; i++) {
         normalizedData[i] = data[i] * scale + _offset;
     }
-    console.timeLog("parseFITSImage", "normalizeData");
+    console.timeLog("normalizeData", "normalizeData");
 
-    console.timeEnd("parseFITSImage", "parseFITSImage done");
-
-    // console.log(header, normalizedData);
-    return [header, normalizedData, width, height, data];
+    return normalizedData;
 }
-
 
 function zscale(
     values,
+    histogram,
+    autoZscale,
     n_samples = 1000,
     contrast = 0.25,
     max_reject = 0.5,
@@ -144,6 +147,12 @@ function zscale(
     max_iterations = 5
 ) {
     console.time("zscale");
+
+    if (!autoZscale) {
+        const vmin = histogram.min;
+        const vmax = histogram.max;
+        return { vmin, vmax };
+    }
 
     // Sample the image
     const stride = Math.max(1, Math.floor(values.length / n_samples));

--- a/webview.html
+++ b/webview.html
@@ -164,6 +164,7 @@
       let activeContextMenu = null;
       let showGrid = false;
       let wcs = null;
+      let autoZScale = true;
 
       const mainContainer = document.querySelector(".mainContainer");
       const headerTab = document.getElementById("headerTab");
@@ -1093,7 +1094,7 @@
       // Wire up controls
       autoZ.addEventListener("click", () => {
         if (!imageData) return;
-        const z = zscale(imageData);
+        const z = zscale(imageData, histogram, autoZScale);
         // Set sliders to the percentiles corresponding to zscale values
         const pmin = percentileForValue(z.vmin);
         const pmax = percentileForValue(z.vmax);
@@ -1617,8 +1618,13 @@
         console.timeLog("renderMonochromeImage", "DataView created");
 
         // Step 3: Parse the FITS header and data
-        [headerData, normalizedData, imageWidth, imageHeight, imageData] =
-          parseFITSImage(arrayBuffer, dataView);
+        [headerData, imageWidth, imageHeight, imageData] = parseFITSImage(arrayBuffer, dataView);
+
+        // Step 4: normalize data for displaying
+        normalizedData = normalizeData(imageData);
+
+        // Step 5: build histogram and set percentile sliders (0-100th percentile)
+        histogram = buildHistogram(imageData, 4096);
 
         displayHeaderTable(headerData);
 
@@ -1685,9 +1691,7 @@
 
         // Initialize stretch sliders and values based on data
         try {
-          // build histogram and set percentile sliders (0-100th percentile)
-          histogram = buildHistogram(imageData, 4096);
-          const z = zscale(imageData);
+          const z = zscale(imageData, histogram, autoZScale);
 
           // slider range is percent
           stretchMin.min = 0;
@@ -1937,6 +1941,30 @@
       console.time("loadData");
       window.addEventListener("message", (event) => {
         const message = event.data;
+        // Set autoZscale when event data contains it
+        // This shall be called BEFORE reacting to settingChanged
+        if (message.autoZScale !== undefined) {
+            autoZScale = message.autoZScale;
+        }
+        // React to changes of settings by the user
+        if (message.command === 'settingChanged') {
+            autoZScale = message.autoZScale;
+            if (imageData) {
+                if (autoZScale) {
+                    // Re-run auto z-scale (simulate clicking the Auto button)
+                    document.getElementById('autoZ').click();
+                } else {
+                    // Reset to full data range
+                    const stretchMin = document.getElementById('stretchMin');
+                    const stretchMax = document.getElementById('stretchMax');
+                    stretchMin.value = stretchMin.min;
+                    stretchMax.value = stretchMax.max;
+                    stretchMin.dispatchEvent(new Event('input'));
+                    stretchMax.dispatchEvent(new Event('input'));
+                }
+            }
+            return;
+        }
         if (message.command === "loadData") {
           renderMonochromeImage(message.fileUri);
           setupZoom(); // Initialize zoom after rendering

--- a/webview.html
+++ b/webview.html
@@ -165,6 +165,7 @@
       let showGrid = false;
       let wcs = null;
       let autoZScale = true;
+      let doDrawApertureCircles = true;
 
       const mainContainer = document.querySelector(".mainContainer");
       const headerTab = document.getElementById("headerTab");
@@ -1857,7 +1858,9 @@
           // Reject hot pixels: real stars have sharpness > ~0.3 (PSF spreads
           // light to neighbors), while hot pixels drop to ~0 at bin 1.
           if (snr > 5 && fwhmResult.fwhm > 0 && fwhmResult.sharpness > 0.2) {
-            drawApertureCircles(fwhmResult, scaleX / currentTransform.k);
+            if (doDrawApertureCircles) {
+                drawApertureCircles(fwhmResult, scaleX / currentTransform.k);
+            }
 
             // Display FWHM information
             let fwhm = fwhmResult.fwhm;
@@ -1946,9 +1949,13 @@
         if (message.autoZScale !== undefined) {
             autoZScale = message.autoZScale;
         }
+        if (message.doDrawApertureCircles !== undefined) {
+            doDrawApertureCircles = message.doDrawApertureCircles;
+        }
         // React to changes of settings by the user
         if (message.command === 'settingChanged') {
             autoZScale = message.autoZScale;
+            doDrawApertureCircles = message.doDrawApertureCircles;
             if (imageData) {
                 if (autoZScale) {
                     // Re-run auto z-scale (simulate clicking the Auto button)

--- a/webview.html
+++ b/webview.html
@@ -1095,7 +1095,7 @@
       // Wire up controls
       autoZ.addEventListener("click", () => {
         if (!imageData) return;
-        const z = zscale(imageData, histogram, autoZScale);
+        const z = zscale(imageData, histogram, true);
         // Set sliders to the percentiles corresponding to zscale values
         const pmin = percentileForValue(z.vmin);
         const pmax = percentileForValue(z.vmax);


### PR DESCRIPTION
This PR includes:

* Optionally render the image with full Z-scale instead of automatic IRAF rescaling; 
* Optionally skip rendering of aperture circles.

Both default to legacy behavior, can be enabled/disabled via VSCode settings.