### PR TITLE
Enhance/platescale

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -62,15 +62,17 @@ class FITSFileEditor {
                             const config = vscode.workspace.getConfiguration('simple-fits-viewer');
                             const autoZScale = config.get('autoZScale', true);
                             const doDrawApertureCircles = config.get('drawApertureCircles', true);
+                            const useGPU = config.get('useGPU', true);
 
-                            log(`Webview ready — sending loadData (autoZScale=${autoZScale}, drawApertureCircles=${doDrawApertureCircles})`);
+                            log(`Webview ready — sending loadData (autoZScale=${autoZScale}, drawApertureCircles=${doDrawApertureCircles}, useGPU=${useGPU})`);
 
                             // Send the data to the webview
                             webviewPanel.webview.postMessage({
                                 command: 'loadData',
                                 fileUri: fitsFileUri.toString(),
                                 autoZScale: autoZScale,
-                                doDrawApertureCircles: doDrawApertureCircles
+                                doDrawApertureCircles: doDrawApertureCircles,
+                                useGPU: useGPU
                             });
                         }
 
@@ -118,6 +120,15 @@ class FITSFileEditor {
                 webviewPanel.webview.postMessage({
                     command: 'settingChanged',
                     doDrawApertureCircles: doDrawApertureCircles
+                });
+            }
+            if (e.affectsConfiguration('simple-fits-viewer.useGPU')) {
+                const config = vscode.workspace.getConfiguration('simple-fits-viewer');
+                const useGPU = config.get('useGPU', true);
+                log(`Setting changed: useGPU=${useGPU}`);
+                webviewPanel.webview.postMessage({
+                    command: 'settingChanged',
+                    useGPU: useGPU
                 });
             }
         });

--- a/extension.js
+++ b/extension.js
@@ -12,7 +12,9 @@ function log(message) {
 function activate(context) {
     log("Extension 'simple-fits-viewer' is now active!");
     context.subscriptions.push(
-        vscode.window.registerCustomEditorProvider('fitFileViewer', new FITSFileEditor(context))
+        vscode.window.registerCustomEditorProvider('fitFileViewer', new FITSFileEditor(context), {
+            webviewOptions: { retainContextWhenHidden: true }
+        })
     );
 }
 

--- a/extension.js
+++ b/extension.js
@@ -2,8 +2,15 @@ const vscode = require('vscode');
 const fs = require('fs');
 const path = require('path');
 
+const outputChannel = vscode.window.createOutputChannel('Simple FITS Viewer');
+
+function log(message) {
+    const ts = new Date().toISOString().replace('T', ' ').substring(0, 23);
+    outputChannel.appendLine(`[${ts}] ${message}`);
+}
+
 function activate(context) {
-    console.log("Extension 'simple-fits-viewer' is now active!");
+    log("Extension 'simple-fits-viewer' is now active!");
     context.subscriptions.push(
         vscode.window.registerCustomEditorProvider('fitFileViewer', new FITSFileEditor(context))
     );
@@ -21,6 +28,7 @@ class FITSFileEditor {
     }
 
     openCustomDocument(uri, openContext, token) {
+        log(`Opening document: ${uri.fsPath}`);
         return new FITSFileDocument(uri);
     }
 
@@ -38,6 +46,8 @@ class FITSFileEditor {
         // Function to update webview content
         const updateWebview = () => {
             try {
+                log(`Loading webview for: ${path.basename(document.uri.fsPath)}`);
+
                 // Step 1: Update the webview content
                 webviewPanel.webview.html = this.getWebviewContent(webviewPanel.webview);
 
@@ -53,6 +63,8 @@ class FITSFileEditor {
                             const autoZScale = config.get('autoZScale', true);
                             const doDrawApertureCircles = config.get('drawApertureCircles', true);
 
+                            log(`Webview ready — sending loadData (autoZScale=${autoZScale}, drawApertureCircles=${doDrawApertureCircles})`);
+
                             // Send the data to the webview
                             webviewPanel.webview.postMessage({
                                 command: 'loadData',
@@ -60,6 +72,11 @@ class FITSFileEditor {
                                 autoZScale: autoZScale,
                                 doDrawApertureCircles: doDrawApertureCircles
                             });
+                        }
+
+                        if (message.command === 'log') {
+                            const prefix = { error: '[ERROR]', warn: '[WARN]', time: '[TIME]' }[message.level] || '[LOG]';
+                            log(`[webview] ${prefix} ${message.message}`);
                         }
 
                         if (message.command === 'openExternal' && message.url) {
@@ -75,7 +92,7 @@ class FITSFileEditor {
                 );
 
             } catch (error) {
-                console.log(error);
+                log(`[ERROR] ${error.message}\n${error.stack}`);
                 vscode.window.showErrorMessage(`Error reading FITS file: ${error.message}`);
             }
         };
@@ -88,6 +105,7 @@ class FITSFileEditor {
             if (e.affectsConfiguration('simple-fits-viewer.autoZScale')) {
                 const config = vscode.workspace.getConfiguration('simple-fits-viewer');
                 const autoZScale = config.get('autoZScale', true);
+                log(`Setting changed: autoZScale=${autoZScale}`);
                 webviewPanel.webview.postMessage({
                     command: 'settingChanged',
                     autoZScale: autoZScale
@@ -96,6 +114,7 @@ class FITSFileEditor {
             if (e.affectsConfiguration('simple-fits-viewer.drawApertureCircles')) {
                 const config = vscode.workspace.getConfiguration('simple-fits-viewer');
                 const doDrawApertureCircles = config.get('drawApertureCircles', true);
+                log(`Setting changed: drawApertureCircles=${doDrawApertureCircles}`);
                 webviewPanel.webview.postMessage({
                     command: 'settingChanged',
                     doDrawApertureCircles: doDrawApertureCircles
@@ -112,6 +131,7 @@ class FITSFileEditor {
 
         // Clean up subscriptions when panel is disposed
         webviewPanel.onDidDispose(() => {
+            log(`Webview disposed: ${path.basename(document.uri.fsPath)}`);
             changeDocumentSubscription.dispose();
             configChangeSubscription.dispose();
         });
@@ -137,6 +157,47 @@ class FITSFileEditor {
         // Attach styles.css
         const stylePath = path.join(__dirname, 'style.css');
         const styleContent = fs.readFileSync(stylePath, 'utf8');
+
+        // Console bridge: forwards webview console output to the extension OutputChannel.
+        // Must be injected after vscode (acquireVsCodeApi) is defined in the main script,
+        // and before utils.js so the timing overrides are in place when those functions run.
+        const consoleBridge = `
+(function () {
+    const _timers = {};
+    const _orig = {
+        log: console.log.bind(console),
+        warn: console.warn.bind(console),
+        error: console.error.bind(console),
+        time: console.time.bind(console),
+        timeLog: console.timeLog.bind(console),
+        timeEnd: console.timeEnd.bind(console),
+    };
+    function serialize(args) {
+        return args.map(a => (a !== null && typeof a === 'object') ? JSON.stringify(a) : String(a)).join(' ');
+    }
+    function postLog(level, message) {
+        vscode.postMessage({ command: 'log', level, message });
+    }
+    console.log = function (...args) { postLog('log', serialize(args)); _orig.log(...args); };
+    console.warn = function (...args) { postLog('warn', serialize(args)); _orig.warn(...args); };
+    console.error = function (...args) { postLog('error', serialize(args)); _orig.error(...args); };
+    console.time = function (label) { _timers[label] = performance.now(); _orig.time(label); };
+    console.timeLog = function (label, ...data) {
+        const elapsed = _timers[label] !== undefined ? (performance.now() - _timers[label]).toFixed(1) : '?';
+        postLog('time', label + ': ' + elapsed + 'ms' + (data.length ? ' — ' + data.join(' ') : ''));
+        _orig.timeLog(label, ...data);
+    };
+    console.timeEnd = function (label) {
+        const elapsed = _timers[label] !== undefined ? (performance.now() - _timers[label]).toFixed(1) : '?';
+        postLog('time', label + ': ' + elapsed + 'ms (done)');
+        delete _timers[label];
+        _orig.timeEnd(label);
+    };
+})();`;
+
+        // Inject the console bridge inline immediately after acquireVsCodeApi() so it is
+        // active before any console.time() calls in the main webview script fire.
+        content = content.replace('const vscode = acquireVsCodeApi();', `const vscode = acquireVsCodeApi();\n${consoleBridge}`);
 
         // Inject utils.js and styles.css content into the webview HTML
         content = content.replace('</body>', `<script>${utilsContent}</script><script>${fwhmContent}</script><script>${wcsContent}</script><style>${styleContent}</style></body>`);

--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Draw FWHM aperture circles"
+                },
+                "simple-fits-viewer.useGPU": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Use GPU (WebGL) acceleration for rendering FITS images when available."
                 }
             }
         }

--- a/utils.js
+++ b/utils.js
@@ -111,7 +111,7 @@ function parseFITSImage(arrayBuffer, dataView) {
     }
     offset += totalBytes;
     console.timeLog("parseFITSImage", "parseFITSImageData");
-    console.timeEnd("parseFITSImage", "parseFITSImage done");
+    console.timeEnd("parseFITSImage");
 
     // console.log(header, normalizedData);
     return [header, width, height, data];
@@ -119,7 +119,7 @@ function parseFITSImage(arrayBuffer, dataView) {
 
 function normalizeData(data, vmin, vmax) {
     // Normalize Data for Display
-    console.timeLog("parseFITSImage", "zscale");
+    console.time("normalizeData");
     // const normalizedData = data.map(
     //     (value) => ((value - vmin) / (vmax - vmin)) * 255
     // );
@@ -130,7 +130,7 @@ function normalizeData(data, vmin, vmax) {
     for (let i = 0; i < data.length; i++) {
         normalizedData[i] = data[i] * scale + _offset;
     }
-    console.timeLog("normalizeData", "normalizeData");
+    console.timeEnd("normalizeData");
 
     return normalizedData;
 }
@@ -151,6 +151,7 @@ function zscale(
     if (!autoZscale) {
         const vmin = histogram.min;
         const vmax = histogram.max;
+        console.timeEnd("zscale");
         return { vmin, vmax };
     }
 
@@ -233,6 +234,7 @@ function zscale(
         vmax = Math.min(vmax, median + (npix - center_pixel) * slope);
     }
     console.timeLog("zscale", "updateMinMax");
+    console.timeEnd("zscale");
 
     return { vmin, vmax };
 }

--- a/webview.html
+++ b/webview.html
@@ -1890,9 +1890,6 @@
           .scaleExtent([1, 100]) // Zoom range
           .on("zoom", (event) => {
             let transform = event.transform;
-            currentTransform = transform;
-
-            imageInteractionHandler(event.sourceEvent, imageWidth, imageHeight);
 
             const right =
               (transform.x - imageWidth / scaleX) / (transform.k / scaleX) +
@@ -1926,6 +1923,10 @@
               transform.y = top_scaled - bottom_scaled;
             }
 
+            // Update currentTransform only after clamping so the line profile
+            // always uses the same transform that is applied to the image.
+            currentTransform = transform;
+
             // Compute visible canvas size and resample from the original resolution
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             ctx.save();
@@ -1938,6 +1939,12 @@
 
             if (showGrid) {
               drawWCSGrid();
+            }
+
+            // Update line profile after currentTransform is clamped so the
+            // profile position matches the rendered image position.
+            if (event.sourceEvent) {
+              imageInteractionHandler(event.sourceEvent, imageWidth, imageHeight);
             }
           });
 

--- a/webview.html
+++ b/webview.html
@@ -1652,18 +1652,29 @@
 
         updateGridToggleVisibility(Boolean(wcs));
 
-        try {
-          // Get the pixel pitch and focal length from the FITS header
-          let pitch = parseFloat(headerData["XPIXSZ"].split("/")[0]);
-          let focalLength = parseFloat(headerData["FOCALLEN"].split("/")[0]);
-          let focalUnits = headerData["FOCALLEN"].split("/")[1];
-          if (focalUnits.includes("mm")) {
-            focalLength /= 1000;
+        if (wcs) {
+          // Derive plate scale from WCS CD matrix (arcsec/pixel)
+          const cd = wcs.cd;
+          const wcsScale = Math.sqrt(cd[0][0] ** 2 + cd[1][0] ** 2) * 3600;
+          if (wcsScale > 0) {
+            plateScale = wcsScale;
+            console.log("Plate scale from WCS:", plateScale);
           }
-          plateScale =
-            Math.atan((pitch * 1e-6) / focalLength) * (180 / Math.PI) * 3600;
-        } catch (error) {
-          console.error("Error parsing plate scale", error);
+        }
+        if (!plateScale) {
+          try {
+            // Fall back to pixel pitch and focal length from the FITS header
+            let pitch = parseFloat(headerData["XPIXSZ"].split("/")[0]);
+            let focalLength = parseFloat(headerData["FOCALLEN"].split("/")[0]);
+            let focalUnits = headerData["FOCALLEN"].split("/")[1];
+            if (focalUnits.includes("mm")) {
+              focalLength /= 1000;
+            }
+            plateScale =
+              Math.atan((pitch * 1e-6) / focalLength) * (180 / Math.PI) * 3600;
+          } catch (error) {
+            console.error("Error parsing plate scale", error);
+          }
         }
 
         console.timeLog("renderMonochromeImage", "Plate scale calculated");

--- a/webview.html
+++ b/webview.html
@@ -458,21 +458,22 @@
           histSep.style.margin = "6px 0";
           contextMenu.appendChild(histSep);
 
-          // Determine x-axis range from BITPIX
+          // Determine x-axis range options
           const bitpixRaw = headerData["BITPIX"]
             ? parseInt(headerData["BITPIX"].split("/")[0])
             : null;
-          let histXMin = 0;
-          let histXMax = histogram.max;
-          if (bitpixRaw && bitpixRaw > 0) {
-            // Integer data: range is 0 to 2^bits - 1
-            histXMin = 0;
-            histXMax = Math.pow(2, bitpixRaw) - 1;
-          } else {
-            // Float data: use actual data range
-            histXMin = histogram.min;
-            histXMax = histogram.max;
-          }
+          const isIntegerBitpix = bitpixRaw && bitpixRaw > 0;
+          const bitpixXMin = 0;
+          const bitpixXMax = isIntegerBitpix
+            ? Math.pow(2, bitpixRaw) - 1
+            : histogram.max;
+          const dataXMin = histogram.min;
+          const dataXMax = histogram.max;
+
+          // Default: BITPIX range for integer data, data range for floats
+          let useBitpixRange = isIntegerBitpix;
+          let histXMin = useBitpixRange ? bitpixXMin : dataXMin;
+          let histXMax = useBitpixRange ? bitpixXMax : dataXMax;
 
           const histW = 300, histH = 150;
           const padL = 50, padR = 10, padT = 5, padB = 25;
@@ -492,6 +493,12 @@
           histTitle.textContent = "Histogram";
           histHeader.appendChild(histTitle);
 
+          // Group the toggles so they sit close together on the right
+          const histToggleGroup = document.createElement("div");
+          histToggleGroup.style.display = "flex";
+          histToggleGroup.style.alignItems = "center";
+          histToggleGroup.style.gap = "8px";
+
           const histLogLabel = document.createElement("label");
           histLogLabel.style.display = "flex";
           histLogLabel.style.alignItems = "center";
@@ -504,7 +511,27 @@
           histLogCheckbox.checked = true;
           histLogLabel.appendChild(histLogCheckbox);
           histLogLabel.appendChild(document.createTextNode("Log"));
-          histHeader.appendChild(histLogLabel);
+          histToggleGroup.appendChild(histLogLabel);
+
+          // X-axis range toggle: BITPIX full range vs. actual data min/max
+          let histBitpixCheckbox = null;
+          if (isIntegerBitpix) {
+            const histBitpixLabel = document.createElement("label");
+            histBitpixLabel.style.display = "flex";
+            histBitpixLabel.style.alignItems = "center";
+            histBitpixLabel.style.gap = "4px";
+            histBitpixLabel.style.fontSize = "12px";
+            histBitpixLabel.style.cursor = "pointer";
+            histBitpixLabel.style.fontWeight = "normal";
+            histBitpixCheckbox = document.createElement("input");
+            histBitpixCheckbox.type = "checkbox";
+            histBitpixCheckbox.checked = useBitpixRange;
+            histBitpixLabel.appendChild(histBitpixCheckbox);
+            histBitpixLabel.appendChild(document.createTextNode("BITPIX scale"));
+            histToggleGroup.appendChild(histBitpixLabel);
+          }
+
+          histHeader.appendChild(histToggleGroup);
 
           contextMenu.appendChild(histHeader);
 
@@ -569,20 +596,27 @@
             return val.toPrecision(3);
           }
 
-          // Build display bins with a fixed pixel-value width of 10
-          // for integer images, or fall back to plot-width bins for floats
-          const isIntegerBitpix = bitpixRaw && bitpixRaw > 0;
-          const valueBinWidth = isIntegerBitpix ? 10 : (histXMax - histXMin) / plotW;
-          const numValueBins = Math.ceil((histXMax - histXMin) / valueBinWidth) || 1;
-          const binnedCounts = new Float64Array(numValueBins);
-          for (let i = 0; i < histogram.nbins; i++) {
-            const binCenter =
-              histogram.min + (i + 0.5) * histogram.binWidth;
-            let di = Math.floor((binCenter - histXMin) / valueBinWidth);
-            if (di < 0) di = 0;
-            if (di >= numValueBins) di = numValueBins - 1;
-            binnedCounts[di] += histogram.counts[i];
+          // Mutable bin state — rebuilt whenever the x-axis range toggle changes
+          let valueBinWidth, numValueBins, binnedCounts, histRange;
+          function rebuildBins() {
+            histXMin = useBitpixRange ? bitpixXMin : dataXMin;
+            histXMax = useBitpixRange ? bitpixXMax : dataXMax;
+            histRange = histXMax - histXMin;
+            // 10-value-wide bins for full BITPIX range; 1px-per-plotpx otherwise
+            valueBinWidth = (isIntegerBitpix && useBitpixRange)
+              ? 10
+              : (histRange / plotW);
+            numValueBins = Math.ceil(histRange / valueBinWidth) || 1;
+            binnedCounts = new Float64Array(numValueBins);
+            for (let i = 0; i < histogram.nbins; i++) {
+              const binCenter = histogram.min + (i + 0.5) * histogram.binWidth;
+              let di = Math.floor((binCenter - histXMin) / valueBinWidth);
+              if (di < 0) di = 0;
+              if (di >= numValueBins) di = numValueBins - 1;
+              binnedCounts[di] += histogram.counts[i];
+            }
           }
+          rebuildBins();
 
           // Selection state
           let selStart = null, selEnd = null, isDragging = false;
@@ -593,7 +627,6 @@
           }
 
           // Map a value-bin index to plot pixel x range
-          const histRange = histXMax - histXMin;
           function binToPlotX(binIdx) {
             const x0 = ((binIdx * valueBinWidth) / histRange) * plotW;
             const x1 = (((binIdx + 1) * valueBinWidth) / histRange) * plotW;
@@ -735,6 +768,15 @@
           histLogCheckbox.addEventListener("change", () => {
             drawHistogram();
           });
+          if (histBitpixCheckbox) {
+            histBitpixCheckbox.addEventListener("change", () => {
+              useBitpixRange = histBitpixCheckbox.checked;
+              selStart = null;
+              selEnd = null;
+              rebuildBins();
+              drawHistogram();
+            });
+          }
 
           // Drag-to-select on histogram
           function histXToPixelVal(px) {

--- a/webview.html
+++ b/webview.html
@@ -143,7 +143,7 @@
 
       let offscreenCanvas, offscreenCtx;
       let useWebGL = false;
-      let webglAvailable = false;
+      let useGPUSetting = true;
       let gl = null;
       let glProgram = null;
       let glUniforms = {};
@@ -370,34 +370,6 @@
 
         contextMenu.appendChild(saveOption);
 
-        // GPU toggle option
-        const gpuOption = document.createElement("div");
-        gpuOption.style.cursor = webglAvailable ? "pointer" : "default";
-        gpuOption.style.padding = "3px";
-        gpuOption.style.opacity = webglAvailable ? "1" : "0.4";
-        if (webglAvailable) {
-          gpuOption.textContent = useWebGL ? "GPU: ON" : "GPU: OFF";
-          addHoverEffect(gpuOption);
-          gpuOption.addEventListener("click", () => {
-            if (useWebGL) {
-              // Switch to CPU
-              useWebGL = false;
-              offscreenCanvas = document.createElement("canvas");
-              offscreenCanvas.width = imageWidth;
-              offscreenCanvas.height = imageHeight;
-              offscreenCtx = offscreenCanvas.getContext("2d");
-              gpuOption.textContent = "GPU: OFF";
-            } else {
-              // Switch to GPU
-              useWebGL = initWebGL(imageWidth, imageHeight, imageData);
-              gpuOption.textContent = useWebGL ? "GPU: ON" : "GPU: OFF";
-            }
-            applyStretchFromInputs();
-          });
-        } else {
-          gpuOption.textContent = "GPU: unavailable";
-        }
-        contextMenu.appendChild(gpuOption);
 
         // Move the stretch controls into the context menu while it's open
         const stretchControlsEl = document.getElementById("stretchControls");
@@ -1685,9 +1657,8 @@
         canvas.width = imageWidth;
         canvas.height = imageHeight;
 
-        // Try WebGL for GPU-accelerated stretch
-        useWebGL = initWebGL(imageWidth, imageHeight, imageData);
-        webglAvailable = useWebGL;
+        // Try WebGL for GPU-accelerated stretch (if enabled in settings)
+        useWebGL = useGPUSetting ? initWebGL(imageWidth, imageHeight, imageData) : false;
         if (useWebGL) {
           console.log("WebGL acceleration enabled");
         } else {
@@ -1975,11 +1946,26 @@
         if (message.doDrawApertureCircles !== undefined) {
             doDrawApertureCircles = message.doDrawApertureCircles;
         }
+        if (message.useGPU !== undefined) {
+            useGPUSetting = message.useGPU;
+        }
         // React to changes of settings by the user
         if (message.command === 'settingChanged') {
             autoZScale = message.autoZScale;
             doDrawApertureCircles = message.doDrawApertureCircles;
-            if (imageData) {
+            if (message.useGPU !== undefined && imageData) {
+                if (useGPUSetting) {
+                    useWebGL = initWebGL(imageWidth, imageHeight, imageData);
+                } else {
+                    useWebGL = false;
+                    offscreenCanvas = document.createElement("canvas");
+                    offscreenCanvas.width = imageWidth;
+                    offscreenCanvas.height = imageHeight;
+                    offscreenCtx = offscreenCanvas.getContext("2d");
+                }
+                applyStretchFromInputs();
+            }
+            if (imageData && message.useGPU === undefined) {
                 if (autoZScale) {
                     // Re-run auto z-scale (simulate clicking the Auto button)
                     document.getElementById('autoZ').click();

--- a/webview.html
+++ b/webview.html
@@ -230,25 +230,34 @@
             window.innerWidth / imageWidth,
             window.innerHeight / imageHeight
           );
-          canvasContainer.style.width = `${imageWidth * scaleFactor - 100}px`;
-          canvasContainer.style.height = `${imageHeight * scaleFactor - 100}px`;
-          canvas.style.width = `${imageWidth * scaleFactor - 100}px`;
-          canvas.style.height = `${imageHeight * scaleFactor - 100}px`;
-          gridCanvas.style.width = `${imageWidth * scaleFactor - 100}px`;
-          gridCanvas.style.height = `${imageHeight * scaleFactor - 100}px`;
+          const displayWidth = imageWidth * scaleFactor - 100;
+          const displayHeight = imageHeight * scaleFactor - 100;
+
+          canvasContainer.style.width = `${displayWidth}px`;
+          canvasContainer.style.height = `${displayHeight}px`;
+          canvas.style.width = `${displayWidth}px`;
+          canvas.style.height = `${displayHeight}px`;
+          gridCanvas.style.width = `${displayWidth}px`;
+          gridCanvas.style.height = `${displayHeight}px`;
 
           rect = canvas.getBoundingClientRect();
 
-          gridCanvas.width = rect.width;
-          gridCanvas.height = rect.height;
+          // rect is zero when the canvas is hidden (header view is showing) —
+          // fall back to the computed display size so the header-container
+          // still gets the correct width on resize.
+          const effectiveWidth = rect.width || displayWidth;
+          const effectiveHeight = rect.height || displayHeight;
 
-          scaleX = canvas.width / rect.width;
-          scaleY = canvas.height / rect.height;
-          xProfileCanvas.width = rect.width;
-          yProfileCanvas.height = rect.height;
+          gridCanvas.width = effectiveWidth;
+          gridCanvas.height = effectiveHeight;
+
+          scaleX = canvas.width / effectiveWidth;
+          scaleY = canvas.height / effectiveHeight;
+          xProfileCanvas.width = effectiveWidth;
+          yProfileCanvas.height = effectiveHeight;
           document.querySelector(
             ".header-container"
-          ).style.width = `${rect.width}px`;
+          ).style.width = `${effectiveWidth}px`;
 
           if (showGrid) {
             drawWCSGrid();


### PR DESCRIPTION
This PR primarily introduces plate scale support derived from WCS data, with additional improvements to logging, rendering, and UI.

### Plate Scale 

* Computes plate scale from WCS information to provide accurate spatial scaling of FITS images.

### Enhancements & Fixes

**Logging and Debugging**

* Adds a dedicated `OutputChannel` with timestamped logging.
* Bridges webview console output (`log`, `warn`, `error`, timing) to the extension.

**Rendering (GPU Toggle)**

* Adds `simple-fits-viewer.useGPU` to enable/disable WebGL rendering.
* Propagates the setting through extension → webview → rendering.

**Histogram & UI**

* Adds a “BITPIX scale” toggle for integer data (full range vs. data min/max).
* Improves adaptive histogram binning.
* Groups histogram controls for a cleaner layout.

**Rendering & Performance**

* Fixes canvas sizing issues during resize/hidden states.
* Improves timing/logging in parsing and normalization.

Overall, the change centers on WCS-derived plate scale, with incremental usability, configurability, and debugging improvements.
