### PR TITLE
Proposal: Render images "bottom-up" for consistency

### DIFF
--- a/lib/fits-viewer.js
+++ b/lib/fits-viewer.js
@@ -10,7 +10,6 @@ const VERT_SRC = `
   varying vec2 v_uv;
   void main() {
     v_uv = a_pos * 0.5 + 0.5;
-    v_uv.y = 1.0 - v_uv.y;
     gl_Position = vec4(a_pos, 0.0, 1.0);
   }`;
 
@@ -607,6 +606,13 @@ export class FITSViewer {
         this.ctx.restore();
     }
 
+    _applyFITSImageTransform(ctx) {
+        ctx.translate(this.currentTransform.x * this.scaleX, this.currentTransform.y * this.scaleY);
+        ctx.scale(this.currentTransform.k, this.currentTransform.k);
+        ctx.translate(0, this.imageHeight - 1);
+        ctx.scale(1, -1);
+    }
+
     _applyStretchFromInputs() {
         const pmin = parseFloat(this.stretchMin.value);
         const pmax = parseFloat(this.stretchMax.value);
@@ -630,21 +636,26 @@ export class FITSViewer {
             const range = vmax - vmin || 1;
             const logDenom = useLog ? Math.log10(1 + range) : 1;
 
-            for (let i = 0, j = 0; i < this.imageData.length; i++, j += 4) {
-                const val = this.imageData[i];
-                let norm = (val - vmin) / range;
-                if (norm < 0) norm = 0;
-                if (norm > 1) norm = 1;
-                if (useLog) {
-                    norm = Math.log10(1 + norm * range) / logDenom;
+            for (let srcY = 0; srcY < height; srcY++) {
+                const srcRow = srcY * width;
+                const dstRow = (height - 1 - srcY) * width * 4;
+                for (let x = 0; x < width; x++) {
+                    const val = this.imageData[srcRow + x];
+                    let norm = (val - vmin) / range;
+                    if (norm < 0) norm = 0;
+                    if (norm > 1) norm = 1;
+                    if (useLog) {
+                        norm = Math.log10(1 + norm * range) / logDenom;
+                    }
+                    const g = gamma <= 0 ? 1 : gamma;
+                    norm = Math.pow(norm, 1 / g);
+                    const c = Math.round(norm * 255);
+                    const j = dstRow + x * 4;
+                    out[j] = c;
+                    out[j + 1] = c;
+                    out[j + 2] = c;
+                    out[j + 3] = 255;
                 }
-                const g = gamma <= 0 ? 1 : gamma;
-                norm = Math.pow(norm, 1 / g);
-                const c = Math.round(norm * 255);
-                out[j] = c;
-                out[j + 1] = c;
-                out[j + 2] = c;
-                out[j + 3] = 255;
             }
             this.offscreenCtx.putImageData(pixels, 0, 0);
         }
@@ -764,14 +775,15 @@ export class FITSViewer {
         const y = Math.floor((event.clientY - this.rect.top) * this.scaleY);
 
         const transformedX = Math.floor((x - this.currentTransform.x * this.scaleX) / this.currentTransform.k);
-        const transformedY = Math.floor((y - this.currentTransform.y * this.scaleY) / this.currentTransform.k);
+        const transformedDisplayY = Math.floor((y - this.currentTransform.y * this.scaleY) / this.currentTransform.k);
+        const transformedY = height - 1 - transformedDisplayY;
 
         const xWidth = Math.ceil(width / this.currentTransform.k);
         const yHeight = Math.ceil(height / this.currentTransform.k);
         const left = Math.floor((-this.currentTransform.x * this.scaleX) / this.currentTransform.k);
         const top = Math.floor((-this.currentTransform.y * this.scaleY) / this.currentTransform.k);
 
-        if (transformedX >= 0 && transformedX < width && transformedY >= 0 && transformedY < height) {
+        if (transformedX >= 0 && transformedX < width && transformedDisplayY >= 0 && transformedDisplayY < height) {
             const xProfile = this.imageData.slice(
                 transformedY * width + left,
                 transformedY * width + left + xWidth + 1
@@ -779,7 +791,8 @@ export class FITSViewer {
             const yLen = Math.min(yHeight + 1, height - top);
             const yProfile = new Float32Array(yLen);
             for (let i = 0; i < yLen; i++) {
-                yProfile[i] = this.imageData[(top + i) * width + transformedX];
+                const imageY = height - 1 - (top + i);
+                yProfile[i] = this.imageData[imageY * width + transformedX];
             }
 
             this._drawLineProfile(this.xProfileCtx, xProfile, true,
@@ -804,8 +817,7 @@ export class FITSViewer {
 
                 this._blitToCanvas();
                 this.ctx.save();
-                this.ctx.translate(this.currentTransform.x * this.scaleX, this.currentTransform.y * this.scaleY);
-                this.ctx.scale(this.currentTransform.k, this.currentTransform.k);
+                this._applyFITSImageTransform(this.ctx);
 
                 const snr = fwhmResult.backgroundSigma > 0
                     ? (fwhmResult.peak - fwhmResult.background) / fwhmResult.backgroundSigma
@@ -837,8 +849,7 @@ export class FITSViewer {
     _drawCachedAperture() {
         if (!this._lastFwhmValid || !this._lastFwhmResult || !this.doDrawApertureCircles) return;
         this.ctx.save();
-        this.ctx.translate(this.currentTransform.x * this.scaleX, this.currentTransform.y * this.scaleY);
-        this.ctx.scale(this.currentTransform.k, this.currentTransform.k);
+        this._applyFITSImageTransform(this.ctx);
         drawApertureCircles(this._lastFwhmResult, this.scaleX / this.currentTransform.k, this.ctx);
         this.ctx.restore();
     }
@@ -848,7 +859,8 @@ export class FITSViewer {
         const x = (clientX - this.rect.left) * this.scaleX;
         const y = (clientY - this.rect.top) * this.scaleY;
         const px = (x - this.currentTransform.x * this.scaleX) / this.currentTransform.k;
-        const py = (y - this.currentTransform.y * this.scaleY) / this.currentTransform.k;
+        const displayY = (y - this.currentTransform.y * this.scaleY) / this.currentTransform.k;
+        const py = this.imageHeight - 1 - displayY;
         return { px, py };
     }
 
@@ -1370,10 +1382,15 @@ export class FITSViewer {
         const top = (-this.currentTransform.y * this.scaleY) / k;
 
         const margin = 0.1;
+        const boundsLeft = left - xWidth * margin;
+        const boundsTop = top - yHeight * margin;
+        const boundsWidth = xWidth * (1 + 2 * margin);
+        const boundsHeight = yHeight * (1 + 2 * margin);
+        const imageBoundsTop = this.imageHeight - 1 - (boundsTop + boundsHeight);
         let [ramin, ramax, decmin, decmax] = this.wcs.sipGetRadecBounds(
             50 / k,
-            left - xWidth * margin, top - yHeight * margin,
-            xWidth * (1 + 2 * margin), yHeight * (1 + 2 * margin)
+            boundsLeft, imageBoundsTop,
+            boundsWidth, boundsHeight
         );
 
         const pixScale = this.wcs.tanPixelScale();
@@ -1398,7 +1415,7 @@ export class FITSViewer {
                 const xy = this.wcs.sipRadec2Pixelxy(ra, dec);
                 if (!xy) { lastOk = false; continue; }
                 const x = ((xy[0] - left) / (this.imageWidth / k)) * canvas.width;
-                const y = ((xy[1] - top) / (this.imageHeight / k)) * canvas.height;
+                const y = ((this.imageHeight - 1 - xy[1] - top) / (this.imageHeight / k)) * canvas.height;
                 if (lastX !== null && lastY !== null) hits.push(...intersect(x, y, lastX, lastY, canvas.width, canvas.height));
                 if (lastOk) ctx.lineTo(x, y); else ctx.moveTo(x, y);
                 lastOk = true; lastX = x; lastY = y;
@@ -1421,7 +1438,7 @@ export class FITSViewer {
                 const xy = this.wcs.sipRadec2Pixelxy(ra, dec);
                 if (!xy) { lastOk = false; continue; }
                 const x = ((xy[0] - left) / (this.imageWidth / k)) * canvas.width;
-                const y = ((xy[1] - top) / (this.imageHeight / k)) * canvas.height;
+                const y = ((this.imageHeight - 1 - xy[1] - top) / (this.imageHeight / k)) * canvas.height;
                 if (lastX !== null && lastY !== null) hits.push(...intersect(x, y, lastX, lastY, canvas.width, canvas.height));
                 if (lastOk) ctx.lineTo(x, y); else ctx.moveTo(x, y);
                 lastOk = true; lastX = x; lastY = y;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "simple-fits-viewer",
     "displayName": "Simple FITS viewer",
     "description": "Preview FITS images in VSCode.",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "publisher": "ppp-one",
     "author": "@ppp-one",
     "homepage": "https://github.com/ppp-one/simple-fits-viewer",


### PR DESCRIPTION
The typical convention for FITS images is that (0, 0) is in the lower left rather than the upper left like we often think of for an array index.

Obviously you don't have to accept this PR if you disagree, but I was tired of having to invert things in my head (when using this extension) relative to how e.g. DS9 displays the same image, so this PR flips the image display vertically to make it consistent. WCS grid overlay should still work correctly, and "north up" images now actually appear as such.

