### PR TITLE
Fix zScalePanel close behavior and improve close button functionality

### DIFF
--- a/lib/fits-viewer.js
+++ b/lib/fits-viewer.js
@@ -965,7 +965,7 @@ export class FITSViewer {
 
     _showZScalePanel() {
         const existing = document.getElementById('zScalePanel');
-        if (existing) { existing.remove(); return; }
+        if (existing) { existing._close?.(); return; }
 
         const stretchControlsEl = this.container.querySelector('#stretchControls');
         const originalParent = stretchControlsEl.parentNode;
@@ -1026,7 +1026,8 @@ export class FITSViewer {
                 originalParent.appendChild(stretchControlsEl);
             }
         };
-        closeBtn.onclick = () => { restore(); panel.remove(); };
+        panel._close = () => { restore(); panel.remove(); };
+        closeBtn.onclick = panel._close;
 
         const pbody = document.createElement('div');
         pbody.style.padding = '10px 12px';


### PR DESCRIPTION
This pull request makes a small but important improvement to how the ZScale panel is managed in the `FITSViewer` class. Instead of immediately removing an existing panel from the DOM, it now calls a dedicated cleanup method to ensure proper restoration of UI elements.

Improvements to ZScale panel management:

* Changed the logic in `_showZScalePanel` so that if the ZScale panel already exists, it calls its `_close` method (if present) for proper cleanup instead of just removing the element. (`lib/fits-viewer.js`)
* Refactored the panel closing logic: assigned a `_close` method to the panel element to handle both UI restoration and removal, and updated the close button to use this method. (`lib/fits-viewer.js`)